### PR TITLE
Introduce AI Tool Maker

### DIFF
--- a/content/docs/02-foundations/04-tools.mdx
+++ b/content/docs/02-foundations/04-tools.mdx
@@ -96,6 +96,7 @@ There are several providers that offer pre-built tools as **toolkits** that you 
 - **[Stripe agent tools](https://docs.stripe.com/agents)** - Tools for interacting with Stripe.
 - **[Toolhouse](https://docs.toolhouse.ai/toolhouse/using-vercel-ai)** - AI function-calling in 3 lines of code for over 25 different actions.
 - **[Agent Tools](https://ai-sdk-agents.vercel.app/?item=introduction)** - A collection of tools for agents.
+- **[AI Tool Maker](https://github.com/nihaocami/ai-tool-maker)** - A CLI utility to generate AI SDK tools from OpenAPI specs.
 
 <Note>
   Do you have open source tools or tool libraries that are compatible with the


### PR DESCRIPTION
A large use case for tools is to have them call certain apis and feed the response to the LLM. This can be tedious and requires lots of manual work. 

With AI Tool Maker (aitm) we want to be able to generate those tools in one command.